### PR TITLE
feat: detect if application was launched from PowerToys

### DIFF
--- a/trap_windows.go
+++ b/trap_windows.go
@@ -5,6 +5,8 @@ import (
 	"unsafe"
 )
 
+var knownCallers = [2]string{"explorer.exe", "PowerToys.PowerLauncher.exe"}
+
 func getProcessEntry(pid int) (*syscall.ProcessEntry32, error) {
 	snapshot, err := syscall.CreateToolhelp32Snapshot(syscall.TH32CS_SNAPPROCESS, 0)
 	if err != nil {
@@ -28,15 +30,21 @@ func getProcessEntry(pid int) (*syscall.ProcessEntry32, error) {
 }
 
 // StartedByExplorer returns true if the program was invoked by the user double-clicking
-// on the executable from explorer.exe
+// on the executable from explorer.exe or by using "PowerToys Run"
 //
 // It is conservative and returns false if any of the internal calls fail.
 // It does not guarantee that the program was run from a terminal. It only can tell you
-// whether it was launched from explorer.exe
+// whether it was launched from explorer.exe or "PowerToys Run"
 func StartedByExplorer() bool {
 	pe, err := getProcessEntry(syscall.Getppid())
 	if err != nil {
 		return false
 	}
-	return "explorer.exe" == syscall.UTF16ToString(pe.ExeFile[:])
+	caller := syscall.UTF16ToString(pe.ExeFile[:])
+	for _, exe := range &knownCallers {
+		if exe == caller {
+			return true
+		}
+	}
+	return false
 }


### PR DESCRIPTION
With PowerToys there is the possibility to run executable with "[PowerToys Run](https://learn.microsoft.com/it-it/windows/powertoys/run)", which has the same logic as "double click the executable".
This PR implements the detection of this launcher.

Let me know if I need to fix anything 👍🏼 